### PR TITLE
Make highlight flatter

### DIFF
--- a/src/main/resources/css/tour.css
+++ b/src/main/resources/css/tour.css
@@ -9,7 +9,7 @@
 }
 
 .tour-highlight-node {
-    -fx-effect: innershadow( two-pass-box , orange , 10, 0.5, 0, 0);
+    -fx-effect: innershadow(one-pass-box, rgba(255, 165, 0, 0.35), 120, 0.99, 0, 0);
 }
 
 /* Required to stop inner shadow of the tab pane being shown around content */


### PR DESCRIPTION
Intention is to more closely resemble a flat translucent overlay... while subject to the limitations of the inner shadow width. It should also make the highlighting much more obvious, even with a large monitor.

## Before
![highlight-old](https://github.com/user-attachments/assets/5ba949ce-5192-4205-a4b0-719f33f68ee2)
![highlight-old-toolbar](https://github.com/user-attachments/assets/4eebfbfb-067d-49ae-85e1-e0f0a544d6a2)

## After
![highlight-new](https://github.com/user-attachments/assets/8113c294-dade-4127-a32f-1468c3edfec0)
![highlight-new-toolbar](https://github.com/user-attachments/assets/0145f578-a4f2-4cb2-8e31-57302960e92d)