### PR TITLE
Rename Tab pane to sidebar

### DIFF
--- a/src/main/resources/qupath/ext/training/ui/tour.properties
+++ b/src/main/resources/qupath/ext/training/ui/tour.properties
@@ -28,8 +28,8 @@ intro.text = Each page introduces a section of QuPath's user interface which wil
 intro.text.info = You can also use the left and right arrow keys.
 intro.text.tip-1 = This tour works best if you open an image _first_ in QuPath.
 
-tab-pane.title = Tab pane
-tab-pane.text = This is the main tab pane on the left.\n\n \
+tab-pane.title = Sidebar
+tab-pane.text = This is the main pane on the left, which contains several tabs.\n\n \
     Here you can select images in a project, view metadata for each image, \
     see a list of annotations, and create a 'Workflow' from commands you have run.
 tab-pane.text.info = This used to be called the 'Analysis Pane'.\n\


### PR DESCRIPTION
Proposal to fix https://github.com/qupath/qupath-extension-training/issues/23

@alanocallaghan so you don't have to build it, here's how it looks:

<img width="795" height="669" alt="sidebar" src="https://github.com/user-attachments/assets/897df651-0b13-4833-9001-55f45eb043e5" />

Since it has been called 'Analysis pane' for a while, we could go with that - although 'sidebar' does seem to be the *right* name, in which case we can go with it here and then rename it in the UI (and anywhere else we find it).

(Note the info disclaimer was already there and wasn't added in this PR)